### PR TITLE
add build ignores to galaxy config

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,4 +20,9 @@ issues: https://github.com/ansible-collections/microsoft.scom/issues
 build_ignore:
   # https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_distributing.html#ignoring-files-and-folders
   - .gitignore
+  - .github
   - changelogs/.plugin-cache.yaml
+  - .azure-pipelines
+  - .vscode
+  - Containerfile
+  - scripts


### PR DESCRIPTION
##### SUMMARY
Update the build_ignores section of the galaxy.yml to prevent hidden and unnecessary folders from getting built into the collection tarball.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Galaxy.yml
